### PR TITLE
Use sigils to fix deprecation warning

### DIFF
--- a/templates/ntp.conf.erb
+++ b/templates/ntp.conf.erb
@@ -3,19 +3,19 @@
 driftfile <%= @driftfile %>
 
 <% if @interface_ignore.empty? == false then -%>
-<% interface_ignore.each do |int_ignore| -%>
+<% @interface_ignore.each do |int_ignore| -%>
 interface ignore <%= int_ignore %>
 <% end -%>
 <% end -%>
 <% if @interface_listen.empty? == false then -%>
-<% interface_listen.each do |int_listen| -%>
+<% @interface_listen.each do |int_listen| -%>
 interface listen <%= int_listen %>
 <% end -%>
 <% end -%>
 
 <% if @enable_statistics == true -%>
 # Enable this if you want statistics to be logged.                             
-statsdir <%= statsdir %>
+statsdir <%= @statsdir %>
 statistics loopstats peerstats clockstats
 filegen loopstats file loopstats type day enable
 filegen peerstats file peerstats type day enable
@@ -41,11 +41,11 @@ restrict 127.0.0.1
 restrict ::1
 
 <% if @server_enabled == true -%>
-<% if query_networks.empty? == false -%>
+<% if @query_networks.empty? == false -%>
 # Clients from this subnet have unlimited access, but only if
 # cryptographically authenticated.
 # Required for some Nagios checks
-<% query_networks.each do |network| -%>
+<% @query_networks.each do |network| -%>
 <% net = network.split('/') -%>
 restrict <%= net[0] %> mask <%= net[1] %>
 <% end -%>


### PR DESCRIPTION
This commit fixes some deprecation warnings about direct access to external variables. 